### PR TITLE
add relative path functiion

### DIFF
--- a/painterly.js
+++ b/painterly.js
@@ -1,1 +1,6 @@
-module.exports = './'+__dirname+'/textures/';
+var path = require('path')
+var texturePath = __dirname + '/textures'
+
+module.exports = function(dir) {
+  return path.relative(dir, texturePath) + '/'
+}


### PR DESCRIPTION
turns out that my paths were getting messed up in certain scenarios so this makes the api look like this:

```
var getTexturePath = require('painterly-textures')
getTexturePath(__dirname)
```
